### PR TITLE
Enforce google coding style at build time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,3 +122,7 @@ spotless {
     }
 }
 
+tasks.named("build") {
+    dependsOn("spotlessApply")
+    dependsOn("spotlessCheck")
+}


### PR DESCRIPTION
Run "spotlessApply" and "spotlessCheck" automatically at build time. spotlessApply will automatically fix simple Google coding style problems. spotlessCheck will cause a build failure if there are any problems that spotlessApply couldn't fix.

Fixes #27 