### PR TITLE
Removed ghost swerve declaration in container

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -117,10 +117,6 @@ public class RobotContainer {
         .y()
         .onTrue(new InstantCommand(() -> s_Swerve.zeroHeading(m_driverController.getHID())));
 
-    m_driverController
-        .rightBumper()
-        .onTrue(new SwerveCom(s_Swerve, m_driverController, m_driverController.leftBumper()));
-
     angleDown.whileTrue(
         Commands.runEnd(() -> m_angler.setSpeed(0.15), () -> m_angler.stop(), m_angler));
 


### PR DESCRIPTION
We were on a rush when we merged vision into dev and this was part of the old code in vision (the branch is stale and git kept this line of code). This will free up right bumper for more useful keybinds for testing in other branches.