### PR TITLE
Bump dependencies

### DIFF
--- a/vendordeps/Phoenix6-26.3.0.json
+++ b/vendordeps/Phoenix6-26.3.0.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix6-frc2026-latest.json",
     "name": "CTRE-Phoenix (v6)",
-    "version": "26.1.3",
+    "version": "26.3.0",
     "frcYear": "2026",
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -19,14 +19,14 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-java",
-            "version": "26.1.3"
+            "version": "26.3.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "api-cpp",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -40,7 +40,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -54,7 +54,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "api-cpp-sim",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -68,7 +68,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -82,7 +82,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -96,7 +96,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -124,7 +124,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -138,7 +138,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFXS",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -152,7 +152,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -180,7 +180,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANrange",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -194,7 +194,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANdi",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -208,7 +208,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANdle",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -224,7 +224,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-cpp",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_Phoenix6_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -240,7 +240,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_Phoenix6_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -272,7 +272,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -288,7 +288,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -304,7 +304,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -320,7 +320,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -336,7 +336,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -352,7 +352,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFXS",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_SimProTalonFXS",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -368,7 +368,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -384,7 +384,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -400,7 +400,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANrange",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_SimProCANrange",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -416,7 +416,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANdi",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_SimProCANdi",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -432,7 +432,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANdle",
-            "version": "26.1.3",
+            "version": "26.3.0",
             "libName": "CTRE_SimProCANdle",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,9 +1,9 @@
 {
   "fileName": "photonlib.json",
   "name": "photonlib",
-  "version": "v2026.3.4",
+  "version": "v2027.0.0-alpha-2",
   "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
-  "frcYear": "2026",
+  "wpilibYear": "2027_alpha5",
   "mavenUrls": [
     "https://maven.photonvision.org/repository/internal",
     "https://maven.photonvision.org/repository/snapshots"
@@ -13,12 +13,12 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
-      "version": "v2026.3.4",
+      "version": "v2027.0.0-alpha-2",
       "skipInvalidPlatforms": true,
       "isJar": false,
       "validPlatforms": [
         "windowsx86-64",
-        "linuxathena",
+        "linuxsystemcore",
         "linuxx86-64",
         "osxuniversal"
       ]
@@ -28,14 +28,14 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photonlib-cpp",
-      "version": "v2026.3.4",
+      "version": "v2027.0.0-alpha-2",
       "libName": "photonlib",
       "headerClassifier": "headers",
       "sharedLibrary": true,
       "skipInvalidPlatforms": true,
       "binaryPlatforms": [
         "windowsx86-64",
-        "linuxathena",
+        "linuxsystemcore",
         "linuxx86-64",
         "osxuniversal"
       ]
@@ -43,14 +43,14 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
-      "version": "v2026.3.4",
+      "version": "v2027.0.0-alpha-2",
       "libName": "photontargeting",
       "headerClassifier": "headers",
       "sharedLibrary": true,
       "skipInvalidPlatforms": true,
       "binaryPlatforms": [
         "windowsx86-64",
-        "linuxathena",
+        "linuxsystemcore",
         "linuxx86-64",
         "osxuniversal"
       ]
@@ -60,12 +60,12 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photonlib-java",
-      "version": "v2026.3.4"
+      "version": "v2027.0.0-alpha-2"
     },
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-java",
-      "version": "v2026.3.4"
+      "version": "v2027.0.0-alpha-2"
     }
   ]
 }

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,9 +1,9 @@
 {
   "fileName": "photonlib.json",
   "name": "photonlib",
-  "version": "v2027.0.0-alpha-2",
+  "version": "v2026.3.4",
   "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
-  "wpilibYear": "2027_alpha5",
+  "frcYear": "2026",
   "mavenUrls": [
     "https://maven.photonvision.org/repository/internal",
     "https://maven.photonvision.org/repository/snapshots"
@@ -13,12 +13,12 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
-      "version": "v2027.0.0-alpha-2",
+      "version": "v2026.3.4",
       "skipInvalidPlatforms": true,
       "isJar": false,
       "validPlatforms": [
         "windowsx86-64",
-        "linuxsystemcore",
+        "linuxathena",
         "linuxx86-64",
         "osxuniversal"
       ]
@@ -28,14 +28,14 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photonlib-cpp",
-      "version": "v2027.0.0-alpha-2",
+      "version": "v2026.3.4",
       "libName": "photonlib",
       "headerClassifier": "headers",
       "sharedLibrary": true,
       "skipInvalidPlatforms": true,
       "binaryPlatforms": [
         "windowsx86-64",
-        "linuxsystemcore",
+        "linuxathena",
         "linuxx86-64",
         "osxuniversal"
       ]
@@ -43,14 +43,14 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
-      "version": "v2027.0.0-alpha-2",
+      "version": "v2026.3.4",
       "libName": "photontargeting",
       "headerClassifier": "headers",
       "sharedLibrary": true,
       "skipInvalidPlatforms": true,
       "binaryPlatforms": [
         "windowsx86-64",
-        "linuxsystemcore",
+        "linuxathena",
         "linuxx86-64",
         "osxuniversal"
       ]
@@ -60,12 +60,12 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photonlib-java",
-      "version": "v2027.0.0-alpha-2"
+      "version": "v2026.3.4"
     },
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-java",
-      "version": "v2027.0.0-alpha-2"
+      "version": "v2026.3.4"
     }
   ]
 }


### PR DESCRIPTION
Updated vendordeps:

CTRE-Phoenix (v6): 26.1.3 → 26.3.0
photonlib: v2026.3.4 → v2027.0.0-alpha-2


_This PR was generated automatically._